### PR TITLE
Make crossbeam-channel version less specific

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ features = [
 ]
 
 [dependencies]
-crossbeam-channel = "0.5.8"
+crossbeam-channel = "0.5.0"
 
 [dev-dependencies.bevy]
 version = "0.12"


### PR DESCRIPTION
Resolves #2 

Could there be a reason 0.5.8 is preferred? Bevy has it set as 0.5.0 everywhere.