### PR TITLE
Remove crossbeam-channel dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,6 @@ version = "0.15"
 default-features = false
 features = ["bevy_render"]
 
-[dependencies]
-crossbeam-channel = "0.5.0"
-
 [dev-dependencies.bevy]
 version = "0.15"
 default-features = false


### PR DESCRIPTION
Inspired by https://github.com/bevyengine/bevy/blob/v0.15.0/examples/games/loading_screen.rs

it seems that it's now possible to accomplish this without `crossbeam-channel`.