### PR TITLE
Upgrade to Bevy 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,28 +19,10 @@ webgl2 = ["bevy/webgl2"]
 webgpu = ["bevy/webgpu"]
 
 [dependencies.bevy]
-version = "0.15"
+version = "0.16.0-rc.0"
 default-features = false
 features = ["bevy_render"]
 
 [dev-dependencies.bevy]
-version = "0.15"
-default-features = false
-features = [
-    "android_shared_stdcxx",
-    "bevy_asset",
-    "bevy_core_pipeline",
-    "bevy_pbr",
-    "bevy_render",
-    "bevy_state",
-    "bevy_ui",
-    "bevy_winit",
-    "bevy_window",
-    "default_font",
-    "hdr",
-    "multi_threaded",
-    "tonemapping_luts",
-    "ktx2",
-    "zstd",
-    "x11",
-]
+version = "0.16.0-rc.0"
+default-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ webgl2 = ["bevy/webgl2"]
 webgpu = ["bevy/webgpu"]
 
 [dependencies.bevy]
-version = "0.16.0-rc.0"
+version = "0.16.0"
 default-features = false
 features = ["bevy_render"]
 
 [dev-dependencies.bevy]
-version = "0.16.0-rc.0"
+version = "0.16.0"
 default-features = true

--- a/README.md
+++ b/README.md
@@ -14,14 +14,28 @@ See [`examples/states.rs`](examples/states.rs).
 
 ## WebGL2 and WebGPU
 
-Install [wasm-server-runner](https://github.com/jakobhellermann/wasm-server-runner).
+### Build
 
 ```bash
 # WebGL
-cargo run --example states --target=wasm32-unknown-unknown --features=webgl2
+cargo build --target wasm32-unknown-unknown --example "states" --features="webgl2"
 
 # WebGPU
-cargo run --example states --target=wasm32-unknown-unknown --features=webgpu
+cargo build --target wasm32-unknown-unknown --example "states" --features="webgpu"
+```
+
+### Bindgen
+
+```bash
+mkdir -p examples/wasm/target
+wget https://raw.githubusercontent.com/bevyengine/bevy/refs/tags/v0.15.0/examples/wasm/index.html -O examples/wasm/index.html
+wasm-bindgen --out-dir examples/wasm/target --out-name wasm_example --target web target/wasm32-unknown-unknown/debug/examples/states.wasm
+```
+
+### Serve
+
+```bash
+basic-http-server examples/wasm/
 ```
 
 ## Compatibility

--- a/examples/states.rs
+++ b/examples/states.rs
@@ -15,7 +15,7 @@ const EXPECTED_PIPELINES: usize = 29;
 // The value will likely differ on the web due to different implementations of some
 // render features.
 #[cfg(all(target_arch = "wasm32", feature = "webgpu", not(feature = "webgl2")))]
-const EXPECTED_PIPELINES: usize = 23;
+const EXPECTED_PIPELINES: usize = 14;
 // Note: you must add these features to your app. See `Cargo.toml`.
 #[cfg(all(target_arch = "wasm32", feature = "webgl2", not(feature = "webgpu")))]
 const EXPECTED_PIPELINES: usize = 6;

--- a/examples/states.rs
+++ b/examples/states.rs
@@ -11,11 +11,11 @@ enum GameState {
 // This value should be found experimentally by logging `PipelinesReady` in your app
 // during normal use and noting the maximum value.
 #[cfg(not(target_arch = "wasm32"))]
-const EXPECTED_PIPELINES: usize = 10;
+const EXPECTED_PIPELINES: usize = 29;
 // The value will likely differ on the web due to different implementations of some
 // render features.
 #[cfg(all(target_arch = "wasm32", feature = "webgpu", not(feature = "webgl2")))]
-const EXPECTED_PIPELINES: usize = 8;
+const EXPECTED_PIPELINES: usize = 23;
 // Note: you must add these features to your app. See `Cargo.toml`.
 #[cfg(all(target_arch = "wasm32", feature = "webgl2", not(feature = "webgpu")))]
 const EXPECTED_PIPELINES: usize = 6;


### PR DESCRIPTION
There probably won't be a crates.io release until Bevy 0.16.0 is properly released, but you can use this git branch in the mean time.

```toml
[dependencies.bevy_simple_text_input]
git = "https://github.com/rparrett/bevy_pipelines_ready.git"
branch = "bevy-0.16"
```