### PR TITLE
Upgrade to Bevy 0.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
       - name: check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
       - name: check
         run: cargo check
       - name: examples

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ webgl2 = ["bevy/webgl2"]
 webgpu = ["bevy/webgpu"]
 
 [dependencies.bevy]
-version = "0.16.0"
+version = "0.17.0-rc.1"
 default-features = false
 features = ["bevy_render"]
 
 [dev-dependencies.bevy]
-version = "0.16.0"
+version = "0.17.0-rc.1"
 default-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ webgl2 = ["bevy/webgl2"]
 webgpu = ["bevy/webgpu"]
 
 [dependencies.bevy]
-version = "0.17.0-rc.1"
+version = "0.17.0"
 default-features = false
 features = ["bevy_render"]
 
 [dev-dependencies.bevy]
-version = "0.17.0-rc.1"
+version = "0.17.0"
 default-features = true

--- a/examples/states.rs
+++ b/examples/states.rs
@@ -11,11 +11,11 @@ enum GameState {
 // This value should be found experimentally by logging `PipelinesReady` in your app
 // during normal use and noting the maximum value.
 #[cfg(not(target_arch = "wasm32"))]
-const EXPECTED_PIPELINES: usize = 29;
+const EXPECTED_PIPELINES: usize = 35;
 // The value will likely differ on the web due to different implementations of some
 // render features.
 #[cfg(all(target_arch = "wasm32", feature = "webgpu", not(feature = "webgl2")))]
-const EXPECTED_PIPELINES: usize = 14;
+const EXPECTED_PIPELINES: usize = 20;
 // Note: These features can be simplified if your app only builds for one of either
 // webgpu or webgl2. Simply use `#[cfg(target_arch = "wasm32")]`. If your app builds
 // for both, you must add these features (or similar) to your app. See `Cargo.toml`.
@@ -27,7 +27,6 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugins(PipelinesReadyPlugin)
         .init_state::<GameState>()
-        .enable_state_scoped_entities::<GameState>()
         .add_systems(Startup, setup_loading_screen)
         .add_systems(Update, print.run_if(resource_changed::<PipelinesReady>))
         .add_systems(
@@ -48,7 +47,7 @@ fn setup_loading_screen(
 ) {
     commands.spawn((
         Text::new("Pipelines loading...".to_string()),
-        StateScoped(GameState::Loading),
+        DespawnOnExit(GameState::Loading),
     ));
 
     commands.spawn((


### PR DESCRIPTION
There probably won't be a crates.io release until Bevy 0.17.0 is properly released, but you can use this git branch in the mean time.

```toml
[dependencies.bevy_pipelines_ready]
git = "https://github.com/rparrett/bevy_pipelines_ready.git"
branch = "bevy-0.17"
```